### PR TITLE
Fix shellcheck CI workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,4 +6,5 @@ jobs:
   shellcheck:
     runs-on: [ubuntu-latest]
     steps:
+      - uses: 'actions/checkout@v3'
       - uses: 'bewuethr/shellcheck-action@v2'


### PR DESCRIPTION
Same bug as in https://github.com/EliahKagan/palgoviz/pull/51.

This has the CI runner check out the repo.