### PR TITLE
Don't have Dependabot group typeguard updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     groups:
       python-dependencies:
         patterns: ['*']
+        exclude-patterns: ['typeguard']
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
So it's easy to take grouped updates without updating typeguard to a higher major version, which the project does not currently support, as noted in #26.